### PR TITLE
build: do install executable

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -73,4 +73,5 @@ executable(
         libinput, xkbcommon, math, thread_dep, sdl_dep, wlroots_static_dep,
         vulkan_dep
     ],
+    install: true,
 )


### PR DESCRIPTION
In order to launch the binary with for example Mesa being installed not into
the regular /usr prefix but into something like /opt the binary needs to be
launched from the install directory and not only directly from the build
directory.

So actually do install the executable.